### PR TITLE
Exported optionals

### DIFF
--- a/Library/src/ExplicitTypes.cpp
+++ b/Library/src/ExplicitTypes.cpp
@@ -40,6 +40,7 @@
 #include "CSP/Systems/Spaces/UserRoles.h"
 #include "CSP/Systems/Spatial/Anchor.h"
 #include "CSP/Systems/Spatial/PointOfInterest.h"
+#include "CSP/Systems/Users/Authentication.h"
 #include "CSP/Systems/Users/Profile.h"
 #include "CSP/Systems/Users/ThirdPartyAuthentication.h"
 
@@ -129,3 +130,10 @@ template class CSP_API csp::common::Optional<csp::systems::Space>;
 template class CSP_API csp::common::Optional<csp::systems::SpaceAttributes>;
 template class CSP_API csp::common::Optional<csp::common::LoginState>;
 template class CSP_API csp::common::Optional<csp::common::Array<csp::FeatureFlag>>;
+template class CSP_API csp::common::Optional<csp::systems::EventTicketingVendor>;
+template class CSP_API csp::common::Optional<csp::systems::EPointOfInterestType>;
+template class CSP_API csp::common::Optional<csp::systems::EThirdPartyPlatform>;
+template class CSP_API csp::common::Optional<csp::common::Array<csp::systems::EAssetCollectionType>>;
+template class CSP_API csp::common::Optional<csp::systems::InviteUserRoleInfoCollection>;
+template class CSP_API csp::common::Optional<csp::systems::GeoLocation>;
+template class CSP_API csp::common::Optional<csp::systems::TokenOptions>;

--- a/Library/src/ExplicitTypes.cpp
+++ b/Library/src/ExplicitTypes.cpp
@@ -90,6 +90,8 @@ template class CSP_API csp::common::Array<csp::systems::TicketedEvent>;
 template class CSP_API csp::common::Array<csp::systems::TierFeatures>;
 template class CSP_API csp::common::Array<csp::systems::VariantOptionInfo>;
 template class CSP_API csp::common::Array<csp::systems::VersionMetadata>;
+template class CSP_API csp::common::Array<csp::systems::EAssetType>;
+template class CSP_API csp::common::Array<csp::systems::EAssetCollectionType>;
 
 // csp::common::List
 template class CSP_API csp::common::List<csp::common::String>;


### PR DESCRIPTION
Export the optional types needed for the systems wrapping in the SWIG repo.

Continuation of the exported types PR from earlier.